### PR TITLE
Fix: poethepoet (^0.19.0) doesn't match any versions

### DIFF
--- a/.github/workflows/poetry-lock.yml
+++ b/.github/workflows/poetry-lock.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python -

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pre-commit = "^3.1.0"
 pylint = "^2.16.2"
 isort = "^5.12.0"
 autopep8 = "^2.0.1"
-poethepoet = "^0.19.0"
+poethepoet = "^0.18.1"
 
 
 [[tool.poetry.source]]


### PR DESCRIPTION
Reverts HuangFuSL/pytorch-project-template#1

Fixes "Because pytorch-project-template depends on poethepoet (^0.19.0) which doesn't match any versions, version solving failed."